### PR TITLE
Fix build on Windows with MSVS 2017

### DIFF
--- a/src/cxxptl-sdl.cpp
+++ b/src/cxxptl-sdl.cpp
@@ -24,7 +24,11 @@
 #include "cxxptl-sdl.h"
 #include <stdio.h>
 #include <string.h>
+#ifdef _WIN32
+#include <SDL.h>
+#else
 #include <SDL/SDL.h>
+#endif // _WIN32
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN

--- a/src/cxxptl-sdl.h
+++ b/src/cxxptl-sdl.h
@@ -22,8 +22,13 @@
  * @Brief SDL port of the CXXPTL library
  */
 #pragma once
+#ifdef _WIN32
+#include <SDL_thread.h>
+#include <SDL_mutex.h>
+#else
 #include <SDL/SDL_thread.h>
 #include <SDL/SDL_mutex.h>
+#endif
 
 /**
  * @File    cxxptl_sdl.h

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,13 +283,15 @@ Color trace(Ray ray, Random& rnd)
 Color raytraceSinglePixel(double x, double y)
 {
 	Random& rnd = getRandomGen();
-	auto getRay = scene.camera->dof ?
-		[](double x, double y, WhichCamera whichCamera) {
-			return scene.camera->getDOFRay(x, y, whichCamera);
-		} :
-		[](double x, double y, WhichCamera whichCamera) {
-			return scene.camera->getScreenRay(x, y, whichCamera);
-		};
+	const auto getDOFRay = [](double x, double y, WhichCamera whichCamera) {
+		return scene.camera->getDOFRay(x, y, whichCamera);
+	};
+	const auto getScreenRay = [](double x, double y, WhichCamera whichCamera) {
+		return scene.camera->getScreenRay(x, y, whichCamera);
+	};
+	const auto getRay = scene.camera->dof
+		? std::function<Ray(double, double, WhichCamera)>(getDOFRay)
+		: std::function<Ray(double, double, WhichCamera)>(getScreenRay);
 
 	if (scene.camera->stereoSeparation > 0) {
 		Ray leftRay = getRay(x, y, CAMERA_LEFT);

--- a/src/random_generator.cpp
+++ b/src/random_generator.cpp
@@ -42,7 +42,11 @@
  ***************************************************************************/
  
 #include <math.h>
+#ifdef _WIN32
+#include <SDL.h>
+#else
 #include <SDL/SDL.h>
+#endif // _WIN32
 #include "random_generator.h"
 #include "constants.h"
 


### PR DESCRIPTION
* Downloadable SDL package contains 'include' directory with includes,
  so it is directly in the include paths, and there is no 'SDL' parent
  directory. This may be done manually, but it has to either be a script
  for introducing the intermediate directory, or the deployment archive
  will not be the original one from the SDL official site.
* Fix ternary operator usage with lambda functions, by instantiating
  explicit std::function objects. This may lower performance, so it
  should be checked. The reason for the instantiation is, that the
  compiler considers two different possible ternary operator calls,
  based on the function calling conventions. By explicitly specifying a
  function, there is no ambiguity in resolving the ternary operator
  parameters.