### PR TITLE
Fix build on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,16 @@
  * @File main.cpp
  * @Brief Raytracer main file
  */
+#ifdef _WIN32
+#include <SDL.h>
+#include <SDL_events.h>
+#ifdef main
+#undef main
+#endif // main
+#else
 #include <SDL/SDL.h>
 #include <SDL/SDL_events.h>
+#endif // _WIN32
 #include <math.h>
 #include <string.h>
 #include <vector>


### PR DESCRIPTION
* On windows, SDL requires 'Windows' sybsystem, and defines a WinMain
  function, but if the compiled application is a 'Console' one, there is
  no main function defined, to be called by the CRT. Thus the
  compilation failed with linker error.